### PR TITLE
Fix crash in WALPaymentMethodFormStateHandler

### DIFF
--- a/WalleeSDK/WalleeSDK/Flow/WALPaymentMethodFormStateHandler.m
+++ b/WalleeSDK/WalleeSDK/Flow/WALPaymentMethodFormStateHandler.m
@@ -36,8 +36,8 @@
 @implementation WALPaymentMethodFormStateHandler
 
 + (instancetype)stateWithParameters:(NSDictionary *)parameters {
-    NSNumber *paymentMethodId = parameters[WALFlowPaymentMethodsParameter];
-    return [self.class stateWithPaymentMethodId:paymentMethodId.unsignedIntegerValue];
+    WALPaymentMethodConfiguration *paymentMethod = parameters[WALFlowPaymentMethodsParameter];
+    return [self.class stateWithPaymentMethodId:paymentMethod.objectId];
 }
 
 + (instancetype)stateWithPaymentMethodId:(NSUInteger)paymentMethodId {


### PR DESCRIPTION
`WALPaymentMethodFormStateHandler` was expecting `WALFlowPaymentMethodsParameter` to be NSNumber, however it turned to be an instance of `WALPaymentMethodConfiguration`.

Pull requests fixed that issue.